### PR TITLE
allow query string in preconfigured endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ oembetter.addFallback(function(url, options, callback) {
 
 ## Changelog
 
+0.1.22: fixed URL parsing bugs impacting use of preconfigured endpoints that already contain some query string parameters.
+
 0.1.21: Updated links and information in the README.
 
 0.1.20: fixed a nuisance error that was appearing when Facebook was present but `window` was not the default object.

--- a/oembed.js
+++ b/oembed.js
@@ -85,7 +85,9 @@ function oembed(url, options, endpoint, mainCallback, _canonical) {
         oUrl = oUrl.replace('json', 'xml');
       }
       if (options) {
-        var parsed = urls.parse(oUrl);
+        // make sure parsed.query is an object by passing true as
+        // second argument
+        var parsed = urls.parse(oUrl, true);
         var keys = Object.keys(options);
         if (!parsed.query) {
           parsed.query = {};
@@ -93,6 +95,10 @@ function oembed(url, options, endpoint, mainCallback, _canonical) {
         keys.forEach(function(key) {
           parsed.query[key] = options[key];
         });
+        // Clean up things url.format defaults to if they are already there,
+        // ensuring that parsed.query is actually used
+        delete parsed.href;
+        delete parsed.search;
         oUrl = urls.format(parsed);
       }
       return request(oUrl, {
@@ -100,6 +106,7 @@ function oembed(url, options, endpoint, mainCallback, _canonical) {
             'User-Agent': 'oembetter'
           }
         }, function(err, response, body) {
+        console.log('** response for ' + oUrl + ' is ', err, response.statusCode, body);
         if (err || (response.statusCode >= 400)) {
           return callback(err || response.statusCode);
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oembetter",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "description": "A modern oembed client. Allows you to register filters to improve or supply oembed support for sites that don't normally have it. You can also supply a whitelist of services you trust to prevent XSS attacks.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
FM needs this. Could be nice for other projects too. Preconfiguring the youtube endpoint speeds things up a little.