### PR TITLE
Release 1.1.0: stop using xml2js, use fast-xml-parser which has no vulnerabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.0 - 2023-05-03
+
+- Switched to `fast-xml-parser`, eliminating installation warnings about `xml2js`.
+
 ## 1.0.2 - 2022-12-21
 
 - Switched to `node-fetch`, eliminating installation warnings about the unsupported `request` module.

--- a/oembed.js
+++ b/oembed.js
@@ -1,7 +1,7 @@
 const fetch = require('node-fetch');
-const xml2js = require('xml2js');
+const { XMLParser } = require('fast-xml-parser');
+
 const cheerio = require('cheerio');
-const util = require('util');
 
 let forceXml = false;
 
@@ -134,7 +134,8 @@ async function get(url, options) {
 }
 
 async function parseXmlString(body) {
-  const response = await util.promisify(xml2js.parseString)(body, { explicitArray: false });
+  const parser = new XMLParser();
+  const response = parser.parse(body);
   if (!response.oembed) {
     throw new Error('XML response lacks oembed element');
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oembetter",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "A modern oembed client. Allows you to register filters to improve or supply oembed support for sites that don't normally have it. You can also supply a allowlist of services you trust to prevent XSS attacks.",
   "main": "index.js",
   "scripts": {
@@ -25,16 +25,16 @@
   "dependencies": {
     "async": "^0.9.0",
     "cheerio": "^1.0.0-rc.10",
+    "fast-xml-parser": "^4.2.2",
     "node-fetch": "^2.6.7",
-    "urls": "0.0.4",
-    "xml2js": "^0.4.4"
+    "urls": "0.0.4"
   },
   "devDependencies": {
-    "mocha": "^10.0.0",
     "eslint": "^7.25.0",
     "eslint-config-apostrophe": "^3.4.0",
     "eslint-plugin-n": "^15.2.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^5.1.0"
+    "eslint-plugin-promise": "^5.1.0",
+    "mocha": "^10.0.0"
   }
 }


### PR DESCRIPTION
I have:

* Run the tests successfully (note they already cover the case of forcing an XML response to make sure XML parsing is not broken).
* Manually reviewed the parsed output from XML and confirmed it's compatible.
* Verified actual Apostrophe video widgets are not broken.