### PR TITLE
release 1.1.1: hardcode vimeo oembed endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.1 - 2023-09-22
+
+- Hardcode the oembed endpoint for vimeo, which stopped offering oembed metadata on pages.
+
 ## 1.1.0 - 2023-05-03
 
 - Switched to `fast-xml-parser`, eliminating installation warnings about `xml2js`.

--- a/index.js
+++ b/index.js
@@ -221,6 +221,11 @@ module.exports = function(options) {
       domain: 'facebook.com',
       path: /\/posts\//,
       endpoint: 'https://www.facebook.com/plugins/post/oembed.json/'
+    },
+    {
+      domain: 'vimeo.com',
+      path: /\/video\//,
+      endpoint: 'https://vimeo.com/api/oembed.json'
     }
   ];
 

--- a/oembed.js
+++ b/oembed.js
@@ -34,9 +34,8 @@ async function oembed(url, options, endpoint, callback, _canonical) {
         options = {};
       }
 
-      resultUrl = endpoint;
-      options.url = resultUrl;
-      return { resultUrl };
+      options.url = url;
+      return { url: endpoint };
     }
 
     // otherwise discover it

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oembetter",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A modern oembed client. Allows you to register filters to improve or supply oembed support for sites that don't normally have it. You can also supply a allowlist of services you trust to prevent XSS attacks.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Vimeo stopped pushing metadata tags for oembed discovery. This is a little faster anyway. Urgent for a client.

Can be tested in the video widget with any vimeo video URL that should allow embedding. I have done that.