### PR TITLE
Pro 6301 allows all vimeo endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Removes `path` regex check on the vimeo endpoint to allow urls with and without `/video`.
+
 ## 1.1.1 - 2023-09-22
 
 - Hardcode the oembed endpoint for vimeo, which stopped offering oembed metadata on pages.

--- a/index.js
+++ b/index.js
@@ -224,7 +224,6 @@ module.exports = function(options) {
     },
     {
       domain: 'vimeo.com',
-      path: /\/video\//,
       endpoint: 'https://vimeo.com/api/oembed.json'
     }
   ];


### PR DESCRIPTION
[PRO-6301](https://linear.app/apostrophecms/issue/PRO-6301/vimeo-embeds-only-work-if-the-url-has-video-in-it)

## Summary

- Removes `path` regex check on the vimeo endpoint to allow urls with and without `/video`.


## What are the specific steps to test this change?

Can use vimeo urls with and without `/video`.

## What kind of change does this PR introduce?

- [ ] Bug fix
- [X] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
